### PR TITLE
Removed ExtraBlack from FVAR table

### DIFF
--- a/_sources/Linefont.designspace
+++ b/_sources/Linefont.designspace
@@ -77,11 +77,5 @@
                 <dimension name="Width" xvalue="100" />
             </location>
         </instance>
-        <instance filename="instance_ufo/Linefont-ExtraBlack.ufo" name="Linefont ExtraBlack" familyname="Linefont" stylename="ExtraBlack">
-            <location>
-                <dimension name="Weight" xvalue="250" />
-                <dimension name="Width" xvalue="100" />
-            </location>
-        </instance>
     </instances>
 </designspace>


### PR DESCRIPTION
As in Wavefont, we not gonna add the ExtraBlack instance in the FVAR table, only as a position in the STAT table, therefore removing it from the designspace file. When GF will finally agrees to support that instance (which shall happen at some point) we'll integrate it in the font ;)