### PR TITLE
Added supercondensed (25)

### DIFF
--- a/_sources/config.yaml
+++ b/_sources/config.yaml
@@ -11,6 +11,8 @@ stat:
   - name: Width
     tag: wdth
     values:
+    - name: SuperCondensed
+      value: 25
     - name: UltraCondensed
       value: 50
     - name: ExtraCondensed


### PR DESCRIPTION
So sorry for this back and forth, apparently we support SuperCondensed at 25 so I added it. 

I also realised that the font depends on ligatures, which can be tricky cause some environment don't activate them by default. I would therefore recommend to move the substitution to the required ligatures (rlig) feature, that should be activated by default everywhere.

 In MS Word:
<img width="448" alt="Screenshot 2023-09-27 at 12 07 42" src="https://github.com/dy/linefont/assets/12222436/0c59e5f9-8769-4dcc-b077-520b66b8d5e9">
